### PR TITLE
Change `Makefile` shell to `sh`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /bin/sh
 
 .PHONY: init
 init:


### PR DESCRIPTION
We don't use any bash extensions there anyway.
This does make packaging slightly easier, dropping `bash` dependency